### PR TITLE
Fix slowdown by moving overlays less often.

### DIFF
--- a/highlight-parentheses.el
+++ b/highlight-parentheses.el
@@ -156,7 +156,7 @@ This is used to prevent analyzing the same context over and over.")
         (setq attributes (plist-put attributes :background (car bg))))
       (pop bg)
       (dotimes (i 2) ;; front and back
-        (push (make-overlay 0 0) hl-paren-overlays)
+        (push (make-overlay 0 0 nil t) hl-paren-overlays)
         (overlay-put (car hl-paren-overlays) 'face attributes)))
     (setq hl-paren-overlays (nreverse hl-paren-overlays))))
 


### PR DESCRIPTION
Now a new function `hl-paren-initiate-highlight` is in `post-command-hook`
instead of `hl-paren-highlight` itself.  The new function uses a timer to skip
calls to `hl-paren-highlight` in case those come faster than about one in a
quarter of a second.  That easily happens when scrolling by pressing and holding
`C-n`.

Fixes issue #8.

In contrast to the subject of the issue, I don't use an idle timer but a normal
one to ensure that the hl-paren updates are immediately visible from a user's
point of view.